### PR TITLE
Replace deprecated match_add_gregex()

### DIFF
--- a/simple-term.vala
+++ b/simple-term.vala
@@ -66,11 +66,10 @@ class TerminalWindow : Gtk.Window
                 get_color("#54ffff"), get_color("#ffffff") });
 
         try {
-            var regex = new GLib.Regex(link_expr,
+            var regex = new Vte.Regex.for_match(link_expr, -1,
                     GLib.RegexCompileFlags.OPTIMIZE |
-                    GLib.RegexCompileFlags.MULTILINE,
-                    0);
-            link_tag = terminal.match_add_gregex(regex, 0);
+                    GLib.RegexCompileFlags.MULTILINE);
+            link_tag = terminal.match_add_regex(regex, 0);
             terminal.match_set_cursor_type(link_tag, Gdk.CursorType.HAND1);
         } catch (Error e) {
             printerr("Failed to compile regex \"%s\": %s\n", link_expr, e.message);


### PR DESCRIPTION
Fixes

    simple-term.vala:78.24-78.48: warning: Vte.Terminal.match_add_gregex has been deprecated since 0.46

Use match_add_regex() instead.